### PR TITLE
Placeholders for 1104 and 1105

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Identifier | Description
 [TMPRL1101](rules/TMPRL1101.md) | Deadlock detected during workflow run
 [TMPRL1102](rules/TMPRL1102.md) | Workflow finished while handlers are still running
 [TMPRL1103](rules/TMPRL1103.md) | Payload size limit exceeded
+[TMPRL1104](rules/TMPRL1104.md) | Workflow task took longer than expected
+[TMPRL1105](rules/TMPRL1105.md) | External storage reference found but driver not configured
 <!-- TODO:
 [TMPRL1102](rules/TMPRL1102.md) | Payload conversion failure
 [TMPRL1103](rules/TMPRL1103.md) | Using known non-deterministic construct (TODO: often for static analyzers)

--- a/rules/TMPRL1104.md
+++ b/rules/TMPRL1104.md
@@ -1,0 +1,11 @@
+# TMPRL1104 - Workflow task took longer than expected
+
+## Cause
+
+This message is logged when a workflow task takes more than 5 seconds to complete.
+
+## Description
+
+SDKs will emit a log statement when the duration of a workflow task is longer than 5 seconds. The log statement has additional information attached to it to help indicate why the task may have spent more time than expected.
+
+## Remediation

--- a/rules/TMPRL1105.md
+++ b/rules/TMPRL1105.md
@@ -1,0 +1,11 @@
+# TMPRL1105 - External storage reference found but driver not configured
+
+## Cause
+
+The SDK encountered a payload that was previously offloaded to external storage, but the worker or replayer processing it does not have external storage configured drivers configured.
+
+## Description
+
+SDKs will emit a log statement when it encouters a payload that has been externally stored but external storage is not configured. This payload was likely emitted by another worker that had external storage configured. The current worker sees that it is an externally stored payload but has no way to retrieve the content, so it passes the claim payload through the system as-is. Any workflow or activity code that tries to deserialize the payload will likely receive an unexpected value or a deserialization error.
+
+## Remediation


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Add new placeholder rules for external storage work:
- TMPRL1104: Workflow task took longer than expected
- TMPRL1105: External storage reference found but driver not configured

## Why?

SDK will issue logs when workflow task is taking more than 5 seconds and when it detects externally stored payloads by external storage is not configured. The SDK refers to these rule codes so that customers can lookup specific help for these circumstances. These rules are placeholders with minimal information and can be refined over time.

## Checklist

1. How was this tested: N/A
1. Any docs updates needed? Yes, new docs for external storage should be created.
